### PR TITLE
Feature/taskform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hook-form": "^7.58.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -14584,6 +14585,22 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz",
       "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
       "license": "MIT"
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.58.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.58.1.tgz",
+      "integrity": "sha512-Lml/KZYEEFfPhUVgE0RdCVpnC4yhW+PndRhbiTtdvSlQTL8IfVR+iQkBjLIvmmc6+GGoVeM11z37ktKFPAb0FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hook-form": "^7.58.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/components/SideDrawer/SideDrawer.tsx
+++ b/src/components/SideDrawer/SideDrawer.tsx
@@ -14,7 +14,7 @@ interface SideDrawerProps { currentList: TaskList | null, setCurrentList: React.
 
 const SideDrawer = ({ currentList, setCurrentList }: SideDrawerProps) => {
     const [open, setOpen] = useState<boolean>(true);
-    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const isMobile = useMediaQuery(theme.breakpoints.down('md'));
     const [lists, setLists] = useState<TaskList[]>([])
     const toggleDrawer = () => {
         setOpen(prev => !prev);

--- a/src/components/SideDrawer/sideDrawerStyledComponents.tsx
+++ b/src/components/SideDrawer/sideDrawerStyledComponents.tsx
@@ -9,7 +9,7 @@ export const StyledDrawer = styled(Drawer)(({ theme }) => ({
         backgroundColor: theme.palette.primary.main,
         color: theme.palette.common.white,
         boxSizing: 'border-box',
-        [theme.breakpoints.down('sm')]: {
+        [theme.breakpoints.down('md')]: {
             width: '100vw',
         },
     },

--- a/src/components/SideDrawer/sideDrawerStyles.css
+++ b/src/components/SideDrawer/sideDrawerStyles.css
@@ -27,7 +27,7 @@
 
 .mobile__menu-btn {
   position: absolute;
-  top: 8;
+  top: 0;
   right: 8;
   z-index: 1;
 }

--- a/src/components/TaskBoard/TaskBoard.tsx
+++ b/src/components/TaskBoard/TaskBoard.tsx
@@ -3,6 +3,7 @@ import "./taskBoardStyles.css"
 import { TaskList } from '../../types/tasks';
 import { List } from '@mui/material';
 import TaskItem from '../TaskItem/TaskItem';
+import TaskForm from '../TaskForm/TaskForm';
 
 interface TaskBoardProps {
     taskList: TaskList | null
@@ -30,7 +31,7 @@ const TaskBoard = ({ taskList }: TaskBoardProps) => {
                     <h1>Good {getTimeOfDay()}</h1>
                 </header>
                 <section>
-
+                    <TaskForm />
                     <List>
                         {taskList?.tasks.map((task, index) => {
                             return (

--- a/src/components/TaskForm/TaskForm.tsx
+++ b/src/components/TaskForm/TaskForm.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import { StyledTaskItem } from '../TaskItem/taskItemStyledComponents'
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import { Autocomplete, Button, Icon, MenuItem, Select, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { useForm, Controller } from 'react-hook-form'
+
+import "./taskForm.css"
+import theme from '../../theme';
+import { Task } from '../../types/tasks';
+import { StyledTextfield, StyledToggleButton } from './taskFormStyledComponents';
+type TaskFormValues = Omit<Task, 'completed'>;
+
+const TaskForm = () => {
+
+    const { control, handleSubmit, reset } = useForm<TaskFormValues>({
+        defaultValues: {
+            name: '',
+            date: new Date(),
+            priority: 'low',
+            tags: [],
+
+        }
+    })
+
+    const onSubmit = (data: Omit<Task, 'completed'>) => {
+        const newTask: Task = {
+            ...data,
+            completed: false,
+            tags: data.tags || [],
+        };
+
+        console.log(newTask);
+        reset()
+    };
+    return (
+        <StyledTaskItem>
+            <div className='taskform__container'>
+                <section className='taskform__wrapper'>
+                    <Icon sx={{ color: theme.palette.secondary.main }}>
+                        <AddCircleOutlineIcon />
+                    </Icon>
+                    <h1>Add Task...</h1>
+                </section>
+                <form onSubmit={handleSubmit(onSubmit)} className="taskform__form">
+                    <div>
+                        <Controller
+                            name="name"
+                            control={control}
+                            render={({ field }) => <StyledTextfield size='small' label="Task name" fullWidth {...field} />}
+
+                        />
+                    </div>
+                    <div>
+                        <Controller
+                            name="date"
+                            control={control}
+                            render={({ field }) => <StyledTextfield size='small' label="Due date" type="date" InputLabelProps={{ shrink: true }} fullWidth {...field} />}
+                        />
+                    </div>
+                    <Controller
+                        name="tags"
+                        control={control}
+                        render={({ field }) => (
+                            <Autocomplete
+                                multiple
+                                freeSolo
+                                options={[]}
+                                value={field.value}
+                                onChange={(_, newValue) => field.onChange(newValue)}
+                                renderInput={(params) => (
+                                    <StyledTextfield
+                                        {...params}
+                                        size="small"
+                                        label="Hashtags"
+                                        placeholder="Add tags"
+                                    />
+                                )}
+                            />
+                        )}
+                    />
+                    <Controller
+                        name="priority"
+                        control={control}
+                        render={({ field }) => (
+                            <ToggleButtonGroup
+                                exclusive
+                                value={field.value}
+                                onChange={(event, newValue) => {
+
+                                    if (newValue !== null) {
+                                        field.onChange(newValue);
+                                    }
+                                }}
+                                fullWidth
+                                color="primary"
+                            >
+                                <StyledToggleButton size='small' value="high">High</StyledToggleButton>
+                                <StyledToggleButton size='small' value="medium">Medium</StyledToggleButton>
+                                <StyledToggleButton size='small' value="low">Low</StyledToggleButton>
+                            </ToggleButtonGroup>
+                        )}
+                    />
+
+                    <Button type="submit" sx={{ backgroundColor: theme.palette.secondary.main }}>Add Task</Button>
+                </form>
+            </div>
+
+        </StyledTaskItem>
+    )
+}
+
+export default TaskForm

--- a/src/components/TaskForm/TaskForm.tsx
+++ b/src/components/TaskForm/TaskForm.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { StyledTaskItem } from '../TaskItem/taskItemStyledComponents'
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
-import { Autocomplete, Button, Icon, MenuItem, Select, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { Autocomplete, Button, Icon, MenuItem, Select, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { useForm, Controller } from 'react-hook-form'
 
 import "./taskForm.css"
 import theme from '../../theme';
 import { Task } from '../../types/tasks';
-import { StyledTextfield, StyledToggleButton } from './taskFormStyledComponents';
+import { StyledChip, StyledTextfield, StyledToggleButton } from './taskFormStyledComponents';
 type TaskFormValues = Omit<Task, 'completed'>;
 
 const TaskForm = () => {
@@ -39,69 +39,88 @@ const TaskForm = () => {
                     <Icon sx={{ color: theme.palette.secondary.main }}>
                         <AddCircleOutlineIcon />
                     </Icon>
-                    <h1>Add Task...</h1>
+                    <h1 id='add-task-form-title'>Add Task...</h1>
                 </section>
-                <form onSubmit={handleSubmit(onSubmit)} className="taskform__form">
-                    <div>
+                <form onSubmit={handleSubmit(onSubmit)} className="taskform__form" aria-labelledby='add-task-form-title'>
+                    <Stack spacing={3}>
                         <Controller
                             name="name"
                             control={control}
-                            render={({ field }) => <StyledTextfield size='small' label="Task name" fullWidth {...field} />}
+                            render={({ field }) => <StyledTextfield id='task-name' size='small' label="Task name" fullWidth {...field} />}
 
                         />
-                    </div>
-                    <div>
+
                         <Controller
                             name="date"
                             control={control}
-                            render={({ field }) => <StyledTextfield size='small' label="Due date" type="date" InputLabelProps={{ shrink: true }} fullWidth {...field} />}
+                            render={({ field }) => <StyledTextfield id='task-date' size='small' label="Due date" type="date" InputLabelProps={{ shrink: true }} fullWidth {...field} />}
                         />
-                    </div>
-                    <Controller
-                        name="tags"
-                        control={control}
-                        render={({ field }) => (
-                            <Autocomplete
-                                multiple
-                                freeSolo
-                                options={[]}
-                                value={field.value}
-                                onChange={(_, newValue) => field.onChange(newValue)}
-                                renderInput={(params) => (
-                                    <StyledTextfield
-                                        {...params}
-                                        size="small"
-                                        label="Hashtags"
-                                        placeholder="Add tags"
-                                    />
-                                )}
-                            />
-                        )}
-                    />
-                    <Controller
-                        name="priority"
-                        control={control}
-                        render={({ field }) => (
-                            <ToggleButtonGroup
-                                exclusive
-                                value={field.value}
-                                onChange={(event, newValue) => {
 
-                                    if (newValue !== null) {
-                                        field.onChange(newValue);
+                        <Controller
+                            name="tags"
+                            control={control}
+                            render={({ field }) => (
+                                <Autocomplete
+                                    id='task-tags'
+                                    multiple
+                                    freeSolo
+                                    options={[]}
+                                    value={field.value}
+                                    onChange={(_, newValue) => field.onChange(newValue)}
+                                    renderTags={(value: string[], getTagProps) =>
+                                        value.map((option, index) => (
+                                            <StyledChip
+                                                label={`#${option}`}
+                                                {...getTagProps({ index })}
+                                                key={option}
+                                                size='small'
+                                            />
+                                        ))
                                     }
-                                }}
-                                fullWidth
-                                color="primary"
-                            >
-                                <StyledToggleButton size='small' value="high">High</StyledToggleButton>
-                                <StyledToggleButton size='small' value="medium">Medium</StyledToggleButton>
-                                <StyledToggleButton size='small' value="low">Low</StyledToggleButton>
-                            </ToggleButtonGroup>
-                        )}
-                    />
+                                    renderInput={(params) => (
+                                        <StyledTextfield
+                                            {...params}
+                                            size="small"
+                                            label="Hashtags"
+                                            placeholder="Add tags"
+                                        />
+                                    )}
+                                />
+                            )}
+                        />
+                        <Controller
+                            name="priority"
+                            control={control}
+                            render={({ field }) => (
+                                <div>
+                                    <label id="priority-label" style={{ display: 'block', marginBottom: '0.5rem', fontSize: '0.9rem', marginTop: '-0.85rem' }}>
+                                        Priority
+                                    </label>
+                                    <ToggleButtonGroup
+                                        exclusive
+                                        value={field.value}
+                                        onChange={(event, newValue) => {
 
-                    <Button type="submit" sx={{ backgroundColor: theme.palette.secondary.main }}>Add Task</Button>
+                                            if (newValue !== null) {
+                                                field.onChange(newValue);
+                                            }
+                                        }}
+                                        fullWidth
+                                        color="primary"
+                                        aria-labelledby="priority-label"
+                                    >
+                                        <StyledToggleButton size='small' value="high">High</StyledToggleButton>
+                                        <StyledToggleButton size='small' value="medium">Medium</StyledToggleButton>
+                                        <StyledToggleButton size='small' value="low">Low</StyledToggleButton>
+                                    </ToggleButtonGroup>
+                                </div>
+
+                            )}
+                        />
+
+                        <Button aria-label='add-task-button' type="submit" sx={{ backgroundColor: theme.palette.secondary.main, width: "100%" }}>Add Task</Button>
+
+                    </Stack>
                 </form>
             </div>
 

--- a/src/components/TaskForm/taskForm.css
+++ b/src/components/TaskForm/taskForm.css
@@ -1,0 +1,40 @@
+.taskform__wrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  margin-bottom: 1rem;
+}
+
+.taskform__wrapper h1 {
+  font-size: 1rem;
+  color: antiquewhite;
+}
+
+.taskform__container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  overflow: hidden;
+  max-height: 3rem;
+  transition: max-height 0.75s ease;
+  width: 100%;
+  border-radius: 8px;
+}
+
+.taskform__container:hover {
+  max-height: 1000px;
+}
+
+.taskform__form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.taskform__form > * {
+  margin: 0.5rem 0;
+}

--- a/src/components/TaskForm/taskFormStyledComponents.tsx
+++ b/src/components/TaskForm/taskFormStyledComponents.tsx
@@ -1,4 +1,4 @@
-import { styled, TextField, ToggleButton } from "@mui/material";
+import { Chip, styled, TextField, ToggleButton } from "@mui/material";
 
 export const StyledTextfield = styled(TextField)(({ theme }) => ({
 
@@ -32,5 +32,18 @@ export const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
     '&.Mui-selected': {
         color: theme.palette.secondary.main,
         borderColor: theme.palette.secondary.main,
+    },
+}));
+
+export const StyledChip = styled(Chip)(({ theme }) => ({
+    backgroundColor: theme.palette.secondary.light,
+    color: theme.palette.secondary.contrastText,
+    borderColor: theme.palette.secondary.main,
+    fontWeight: 500,
+    fontSize: '0.75rem',
+
+    '& .MuiChip-deleteIcon': {
+        color: theme.palette.secondary.dark,
+
     },
 }));

--- a/src/components/TaskForm/taskFormStyledComponents.tsx
+++ b/src/components/TaskForm/taskFormStyledComponents.tsx
@@ -1,0 +1,36 @@
+import { styled, TextField, ToggleButton } from "@mui/material";
+
+export const StyledTextfield = styled(TextField)(({ theme }) => ({
+
+    '& label.Mui-focused': {
+        color: theme.palette.common.white,
+    },
+    '& .MuiOutlinedInput-root': {
+        '& fieldset': {
+            borderColor: theme.palette.grey[500],
+        },
+        '&:hover fieldset': {
+            borderColor: theme.palette.primary.light,
+        },
+        '&.Mui-focused fieldset': {
+            borderColor: theme.palette.primary.light,
+        },
+    },
+
+}));
+
+export const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
+    textTransform: 'none',
+    borderColor: theme.palette.grey[400],
+    color: theme.palette.text.primary,
+
+    '&:hover': {
+        borderColor: theme.palette.background.default,
+        backgroundColor: "transparent"
+    },
+
+    '&.Mui-selected': {
+        color: theme.palette.secondary.main,
+        borderColor: theme.palette.secondary.main,
+    },
+}));

--- a/src/components/TaskItem/taskItemStyles.css
+++ b/src/components/TaskItem/taskItemStyles.css
@@ -24,17 +24,17 @@
 }
 
 .task-prio-tag.high {
-  background-color: #e53935; /* red */
+  background-color: #e53935;
   color: white;
 }
 
 .task-prio-tag.medium {
-  background-color: #fdd835; /* yellow */
+  background-color: #fdd835;
   color: black;
 }
 
 .task-prio-tag.low {
-  background-color: #1e88e5; /* blue */
+  background-color: #1e88e5;
   color: white;
 }
 


### PR DESCRIPTION
This PR adds a task form that lets users create new tasks with the following fields:

- Task name
- Due date
- Hashtags (via a combo box with chip support)
- Priority (selectable using toggle buttons for High, Medium, or Low)
- A submit button to add the task

The form starts collapsed and expands smoothly when you hover over it — showing just the “Add Task...” label by default for a cleaner look.